### PR TITLE
Hotfix/w1 attribute

### DIFF
--- a/lib/xeroizer/models/payroll/earnings_rate.rb
+++ b/lib/xeroizer/models/payroll/earnings_rate.rb
@@ -23,6 +23,7 @@ module Xeroizer
         decimal       :multiplier
         boolean       :accrue_leave
         decimal       :amount
+        boolean       :is_reportable_as_w1
 
         datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
 

--- a/test/stub_responses/payroll_pay_items.xml
+++ b/test/stub_responses/payroll_pay_items.xml
@@ -14,6 +14,7 @@
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsExemptFromTax>false</IsExemptFromTax>
         <IsExemptFromSuper>false</IsExemptFromSuper>
+        <IsReportableAsW1>true</IsReportableAsW1>
         <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
       </EarningsRate>
       <EarningsRate>
@@ -25,6 +26,7 @@
         <Multiplier>1.5000</Multiplier>
         <IsExemptFromTax>false</IsExemptFromTax>
         <IsExemptFromSuper>true</IsExemptFromSuper>
+        <IsReportableAsW1>true</IsReportableAsW1>
         <AccrueLeave>false</AccrueLeave>
         <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
       </EarningsRate>
@@ -37,6 +39,7 @@
         <TypeOfUnits>Fixed Amount</TypeOfUnits>
         <IsExemptFromTax>false</IsExemptFromTax>
         <IsExemptFromSuper>false</IsExemptFromSuper>
+        <IsReportableAsW1>true</IsReportableAsW1>
         <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
       </EarningsRate>
       <EarningsRate>
@@ -48,6 +51,7 @@
         <TypeOfUnits>Fixed Amount</TypeOfUnits>
         <IsExemptFromTax>true</IsExemptFromTax>
         <IsExemptFromSuper>true</IsExemptFromSuper>
+        <IsReportableAsW1>true</IsReportableAsW1>
         <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
       </EarningsRate>
     </EarningsRates>


### PR DESCRIPTION
 - Xero recently added a new field to the API - reportable as W1
 - This was available through the API, but there wasn't support for it in Xeroizer
 - This lead to Xeroizer records being created without it, meaning it was overridden in Xero when saving these records.  
 - fixed the above issue and added the attribute to the stubs (there isn't an explicit test for this)

Have also tested locally that this fixes the issues.  