### PR TITLE
Hotfix/etp type param

### DIFF
--- a/lib/xeroizer/models/payroll/earnings_rate.rb
+++ b/lib/xeroizer/models/payroll/earnings_rate.rb
@@ -24,6 +24,7 @@ module Xeroizer
         boolean       :accrue_leave
         decimal       :amount
         boolean       :is_reportable_as_w1
+        string        :employment_termination_payment_type
 
         datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
 

--- a/test/stub_responses/payroll_pay_items.xml
+++ b/test/stub_responses/payroll_pay_items.xml
@@ -54,6 +54,18 @@
         <IsReportableAsW1>true</IsReportableAsW1>
         <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
       </EarningsRate>
+      <EarningsRate>
+        <EarningsRateID>683f87af-50f7-4584-9b0b-93d943537945</EarningsRateID>
+        <Name>ETP Type O Payments Subject To Tax</Name>
+        <EarningsType>EMPLOYMENTTERMINATIONPAYMENT</EarningsType>
+        <RateType>FIXEDAMOUNT</RateType>
+        <AccountCode>477</AccountCode>
+        <IsExemptFromTax>false</IsExemptFromTax>
+        <IsExemptFromSuper>true</IsExemptFromSuper>
+        <IsReportableAsW1>false</IsReportableAsW1>
+        <UpdatedDateUTC>2018-02-07T01:01:25</UpdatedDateUTC>
+        <EmploymentTerminationPaymentType>O</EmploymentTerminationPaymentType>
+      </EarningsRate>
     </EarningsRates>
     <DeductionTypes>
       <DeductionType>


### PR DESCRIPTION
Problem:

- Xero added a field EmploymentTerminationPaymentType to the api recently, isn't supported in Xeroizer yet.  
- when we tried to bulk save pay items, it would fail if there was an ETP pay item in there, because ETP Payment type was needed
- this would only give us 500's though, no actual validation (pranked).  
- fixes the above, will point Tanda to new commit once merged