### PR TITLE
ADD: ResidencyStatus param to TaxDeclaration class for Xero

### DIFF
--- a/lib/xeroizer/models/payroll/tax_declaration.rb
+++ b/lib/xeroizer/models/payroll/tax_declaration.rb
@@ -13,6 +13,7 @@ module Xeroizer
         string       :tax_file_number
         string       :tfn_exemption_type, :api_name => 'TFNExemptionType'
         boolean      :australian_resident_for_tax_purposes
+        string       :residency_status, :api_name => 'ResidencyStatus'
         boolean      :tax_free_threshold_claimed
         decimal      :tax_offset_estimated_amount
         boolean      :has_help_debt, :api_name => 'HasHELPDebt'

--- a/test/stub_responses/records/payroll_employee-fb4ebd68-6568-41eb-96ab-628a0f54b4b8.xml
+++ b/test/stub_responses/records/payroll_employee-fb4ebd68-6568-41eb-96ab-628a0f54b4b8.xml
@@ -29,6 +29,7 @@
         <TaxDeclaration>
           <TFNPendingOrExemptionHeld>false</TFNPendingOrExemptionHeld>
           <AustralianResidentForTaxPurposes>true</AustralianResidentForTaxPurposes>
+          <ResidencyStatus>RESIDENT</ResidencyStatus>
           <TaxFreeThresholdClaimed>true</TaxFreeThresholdClaimed>
           <HasHELPDebt>false</HasHELPDebt>
           <HasSFSSDebt>false</HasSFSSDebt>


### PR DESCRIPTION
This PR adds the `residency_status` attribute to the `TaxDeclaration` class, which is part of the [Xero API](https://developer.xero.com/documentation/payroll-api/employees)

[Residency Status docs](https://developer.xero.com/documentation/payroll-api/types-and-codes#ResidencyStatusand)