### PR TITLE
Fix issue when approving timesheet

### DIFF
--- a/lib/xeroizer/models/payroll/timesheet.rb
+++ b/lib/xeroizer/models/payroll/timesheet.rb
@@ -29,7 +29,10 @@ module Xeroizer
         def approve
           params = extra_params_for_create_or_update
           params[:url] = "Timesheets/#{attributes[:timesheet_id]}/approve"
-          response = parent.send(:http_post, {}, params)
+
+          request = parent.application.api_format == :json ? '{}' : ''
+          response = parent.send(:http_post, request, params)
+
           parse_save_response(response)
         end
 


### PR DESCRIPTION
https://tanda.airbrake.io/projects/116296/groups/2895291819122525187/notices/2976886626305717241?tab=notice-detail


Emulates this
https://github.com/ghiculescu/xeroizer/blob/payroll/lib/xeroizer/record/base.rb#L182-L185

Here
https://github.com/ghiculescu/xeroizer/blob/payroll/lib/xeroizer/models/payroll/timesheet.rb#L32

to_api_json returns a string whereas originally we were passing a hash literal (`{}`)
https://github.com/ghiculescu/xeroizer/blob/payroll/lib/xeroizer/record/base.rb#L213