### PR TITLE
FIX: add missing allowance type to Xeorizer

### DIFF
--- a/lib/xeroizer/models/payroll/earnings_rate.rb
+++ b/lib/xeroizer/models/payroll/earnings_rate.rb
@@ -29,6 +29,7 @@ module Xeroizer
         boolean       :current_record # UK
         boolean       :is_reportable_as_w1
         string        :employment_termination_payment_type
+        string        :allowance_type
 
         datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
 

--- a/test/stub_responses/payroll_pay_items.xml
+++ b/test/stub_responses/payroll_pay_items.xml
@@ -40,6 +40,7 @@
         <IsExemptFromTax>false</IsExemptFromTax>
         <IsExemptFromSuper>false</IsExemptFromSuper>
         <IsReportableAsW1>true</IsReportableAsW1>
+        <AllowanceType>Other</AllowanceType>
         <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
       </EarningsRate>
       <EarningsRate>
@@ -52,6 +53,7 @@
         <IsExemptFromTax>true</IsExemptFromTax>
         <IsExemptFromSuper>true</IsExemptFromSuper>
         <IsReportableAsW1>true</IsReportableAsW1>
+        <AllowanceType>Other</AllowanceType>
         <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
       </EarningsRate>
       <EarningsRate>


### PR DESCRIPTION
Pay items with the `EarningsType` set as "Allowance" also need to have an `AllowanceType` set.   